### PR TITLE
Fixed DeprecationWarning for Django 1.10.

### DIFF
--- a/perfect404/views.py
+++ b/perfect404/views.py
@@ -35,4 +35,4 @@ def page_not_found(request, template_name='perfect404.html'):
                         'referer': referer,
                         'internal': internal,
                         'contact': contact,
-                    })))
+                    }).flatten()))


### PR DESCRIPTION
A RequestContext object needs a flatten() before it can be rendered.
